### PR TITLE
Ajout de la documentation sur les scopes customs

### DIFF
--- a/doc_fs.md
+++ b/doc_fs.md
@@ -1,9 +1,8 @@
 [Accueil](README.md) > ProConnect - Fournisseur de Service
 
-___
+---
 
 # ProConnect - Fournisseur de Service
-
 
 Vous souhaitez implémenter ProConnect sur votre site ? Vous êtes au bon endroit ! Cette documentation présente l'ensemble des informations à connaître.
 
@@ -11,28 +10,29 @@ Vous souhaitez implémenter ProConnect sur votre site ? Vous êtes au bon endroi
 
 Cette documentation est à destination des Fournisseurs de Services souhaitant intégrer ProConnect. ProConnect est implémenté sur deux plateformes, une dite "RIE" (l’agent se connecte depuis le RIE, à un FS RIE via un FI RIE) et une autre dite "Internet" (l'agent se connecte depuis Internet, à un FS Internet via un FI Internet). Toutefois il est possible d'utiliser "l'hybridge Internet/RIE", qui permet aux agents, depuis un Fournisseur de Service **sur Internet**, de s'identifier via un Fournisseur d'Identité **sur le RIE**.
 
-
 ## 2. ⚙️ Les étapes pour intégrer ProConnect
 
-- [ ] Je me familiarise avec le flux OIDC - authorization code flow : voir [concepts de base](resources/flux_oidc.md). NB: si vous êtes Fournisseur de Service, ProConnect est votre *provider* et vous êtes *client*.
+- [ ] Je me familiarise avec le flux OIDC - authorization code flow : voir [concepts de base](resources/flux_oidc.md). NB: si vous êtes Fournisseur de Service, ProConnect est votre _provider_ et vous êtes _client_.
 - [ ] Je souhaite lancer les développements en test : je renseigne [le formulaire dédié](https://www.demarches-simplifiees.fr/commencer/demande-creation-fs-fca). L'équipe me fournit alors mon `client_id` et mon `client_secret`.
 - [ ] J’ai implémenté la cinématique OIDC (Authorization Code Flow): voir l'[implémentation technique](doc_fs/implementation_technique.md)
-- [ ]  Je contractualise officiellement ma collaboration avec la DINUM en remplissant le [DataPass dédié](./doc_fs/datapass-fs.md)
-- [ ]  Le DataPass étant validé, j’ai récupéré mon `client_id` et mon `client_secret` de production en remplissant [le formulaire dédié](https://www.demarches-simplifiees.fr/commencer/demande-creation-fs-fca) avec les informations de production
-- [ ]  Ouverture du service en production 🚀
+- [ ] Je contractualise officiellement ma collaboration avec la DINUM en remplissant le [DataPass dédié](./doc_fs/datapass-fs.md)
+- [ ] Le DataPass étant validé, j’ai récupéré mon `client_id` et mon `client_secret` de production en remplissant [le formulaire dédié](https://www.demarches-simplifiees.fr/commencer/demande-creation-fs-fca) avec les informations de production
+- [ ] Ouverture du service en production 🚀
 
 Pour toute question technique, vous pouvez contacter l'équipe ProConnect par les deux canaux suivants :
+
 - par mail à support.partenaires@agentconnect.gouv.fr
 - [sur notre chaîne Tchap](https://www.tchap.gouv.fr/#/room/!kBghcRpyMNThkFQjdW:agent.dinum.tchap.gouv.fr)
 
-___
+---
 
 ## 3. 💻 FAQ
+
 - [Quels changements dois-je effectuer pour passer d'AgentConnect à ProConnect ?](./doc_fs/changement-agentconnect-proconnect-fs.md)
 - [Quelles sont les données que je peux récupérer par ProConnect sur les agents ?](doc_fs/donnees_fournies.md)
 - [Comment utiliser les scopes OpenID Connect pour accéder aux données des utilisateurs ?](doc_fs/scope-claims.md)
 - [Comment savoir avec quel Fournisseur d'Identité s'est authentifié mon utilisateur ?](doc_fs/connaitre-le-fi-utilise.md)
-- [Comment spécifier à ProConnect que les usagers de mon FS doivent être redirigés directement vers un Fournisseur d'Identité (FI) spécifique ?](doc_fs/idp_hint_usage.md)
+- [Comment spécifier à ProConnect que les usagers de mon FS doivent être redirigés directement vers un Fournisseur d'Identité spécifique ?](doc_fs/idp_hint_usage.md)
+- [Comment récupérer des propriétés "custom" d'un Fournisseur d'Identité?](doc_fs/custom-scope.md)
 - [Erreurs récurrentes](doc_fs/troubleshooting-fs.md)
 - [Glossaire](resources/glossaire.md)
-

--- a/doc_fs/custom-scope.md
+++ b/doc_fs/custom-scope.md
@@ -1,14 +1,16 @@
 # Le scope custom
 
-Ce scope optionnel permet de récupérer toutes les propriétés retournées par l'userinfo d'un Fournisseur d'Identité qui ne sont pas reconnues comme canoniques par ProConnect.
+Ce scope optionnel permet de récupérer toutes les propriétés retournées à l'appel au `userinfo_endpoint` d'un Fournisseur d'Identité qui ne sont pas reconnues comme *canoniques* par ProConnect.
 
-Ces propriétés "canoniques" correspondent aux claims que ProConnect récupère auprès des Fournisseurs d'identité, voici [la liste](../doc_fi/configuration.md#configurer-les-scopes) des scopes associés à ces claims.
+> Les propriétés *canoniques* sont les claims que ProConnect récupère auprès des Fournisseurs d'identité. Vous trouverez [ici](../doc_fi/configuration.md#configurer-les-scopes) la liste des scopes associés à ces claims.
 
-Ces informations sont ensuites déplacées dans un objet "custom".
+Ces propriétés *non canoniques* sont ensuites déplacées dans un objet `custom`.
 
-Quand un Fournisseur de Service demande un scope "custom" l'userinfo de ProConnect retournera cette propriété.
+Quand un Fournisseur de Service demande un scope `custom`, l'appel au `userinfo_endpoint` de ProConnect retournera ces propriétés dans un objet `custom`.
 
-Si le Fournisseur d'Identité n'a retourné aucune propriété non canonique dans son userinfo, ProConnect renverra un champ "custom" retournant un objet vide:
+### Cas n°1 : le Fournisseur d'Identité n'a retourné aucune propriété *non canonique* lors de l'appel à son `userinfo_endpoint`
+
+ProConnect renverra un objet `custom` vide :
 
 ```json
 {
@@ -19,7 +21,9 @@ Si le Fournisseur d'Identité n'a retourné aucune propriété non canonique dan
 
 ```
 
-Si le Fournisseur d'Identité retourne des propriétés non canonique, comme par exemple:
+### Cas n°2 : le Fournisseur d'Identité a retourné des propriétés *non canoniques* lors de l'appel à son `userinfo_endpoint`
+
+Par exemple:
 
 ```json
 {
@@ -30,7 +34,7 @@ Si le Fournisseur d'Identité retourne des propriétés non canonique, comme par
 }
 ```
 
-ProConnect placera ces valeurs dans l'objet custom:
+Dans ce cas, ProConnect placera ces valeurs dans l'objet `custom`:
 
 ```json
 {
@@ -44,7 +48,7 @@ ProConnect placera ces valeurs dans l'objet custom:
 
 ```
 
-Si le Fournisseur de Service ne demande pas de scope custom, l'objet "custom" ne sera, logiquement, pas retourné par ProConnect, même si le Fournisseur d'Identité renvoie des propriétés non canonique :
+NB: Si le Fournisseur de Service ne demande pas de scope `custom`, alors l'objet `custom` ne sera, logiquement, pas retourné par ProConnect, même si le Fournisseur d'Identité renvoie des propriétés *non canoniques*. L'appel au `userinfo_endpoint` de ProConnect renverra donc :
 
 ```json
 {

--- a/doc_fs/custom-scope.md
+++ b/doc_fs/custom-scope.md
@@ -1,0 +1,55 @@
+# Le scope custom
+
+Ce scope optionnel permet de récupérer toutes les propriétés retournées par l'userinfo d'un Fournisseur d'Identité qui ne sont pas reconnues comme canoniques par ProConnect.
+
+Ces propriétés "canoniques" correspondent aux claims que ProConnect récupère auprès des Fournisseurs d'identité, voici [la liste](../doc_fi/configuration.md#configurer-les-scopes) des scopes associés à ces claims.
+
+Ces informations sont ensuites déplacées dans un objet "custom".
+
+Quand un Fournisseur de Service demande un scope "custom" l'userinfo de ProConnect retournera cette propriété.
+
+Si le Fournisseur d'Identité n'a retourné aucune propriété non canonique dans son userinfo, ProConnect renverra un champ "custom" retournant un objet vide:
+
+```json
+{
+  "sub": "sub-proconnect",
+  ...
+  "custom": {}
+  }
+
+```
+
+Si le Fournisseur d'Identité retourne des propriétés non canonique, comme par exemple:
+
+```json
+{
+  "sub": "sub-idp",
+  ...,
+  "structure_travail": "59194",
+  "site_travail": "DRHAUTS-DE-FRANCE/PFPPLATEFORMESERVICESADISTANCE(HDF0262005733)"
+}
+```
+
+ProConnect placera ces valeurs dans l'objet custom:
+
+```json
+{
+  "sub": "7396c91e-b9f2-4f9d-8547-5e9b3332725b",
+  ...
+  "custom": {
+    "structure_travail": "59194",
+    "site_travail": "DRHAUTS-DE-FRANCE/PFPPLATEFORMESERVICESADISTANCE(HDF0262005733)"
+  }
+}
+
+```
+
+Si le Fournisseur de Service ne demande pas de scope custom, l'objet "custom" ne sera, logiquement, pas retourné par ProConnect, même si le Fournisseur d'Identité renvoie des propriétés non canonique :
+
+```json
+{
+  "sub": "7396c91e-b9f2-4f9d-8547-5e9b3332725b",
+  ...
+}
+
+```

--- a/doc_fs/scope-claims.md
+++ b/doc_fs/scope-claims.md
@@ -1,31 +1,30 @@
-
-# Comment utiliser les scopes OpenID Connect pour accéder aux données des utilisateurs ? 
+# Comment utiliser les scopes OpenID Connect pour accéder aux données des utilisateurs ?
 
 ## Scope et Claims dans OpenID Connect
 
-### Qu'est ce qu'un scope dans OpenID Connect ? 
+### Qu'est ce qu'un scope dans OpenID Connect ?
 
-> Les clients OpenID Connect utilisent des *scopes* tels que définis dans la section 3.3 de [OAuth 2.0 [RFC6749]](https://openid.net/specs/openid-connect-basic-1_0.html#RFC6749) pour spécifier quels privilèges d'accès sont demandés pour les *access token*. Les *scopes* associées aux *access token* déterminent les ressources qui seront disponibles lorsqu'elles sont utilisées pour accéder aux *endpoints* protégés par OAuth 2.0. Pour OpenID Connect, les *scopes* peuvent être utilisées pour demander que des ensembles d'informations spécifiques soient mis à disposition en tant que *claims*.
+> Les clients OpenID Connect utilisent des _scopes_ tels que définis dans la section 3.3 de [OAuth 2.0 [RFC6749]](https://openid.net/specs/openid-connect-basic-1_0.html#RFC6749) pour spécifier quels privilèges d'accès sont demandés pour les _access token_. Les _scopes_ associées aux _access token_ déterminent les ressources qui seront disponibles lorsqu'elles sont utilisées pour accéder aux _endpoints_ protégés par OAuth 2.0. Pour OpenID Connect, les _scopes_ peuvent être utilisées pour demander que des ensembles d'informations spécifiques soient mis à disposition en tant que _claims_.
 
-*Source: [OpenID Connect Basic Client Implementer's Guide 1.0](https://openid.net/specs/openid-connect-basic-1_0.html#Scopes)*
+_Source: [OpenID Connect Basic Client Implementer's Guide 1.0](https://openid.net/specs/openid-connect-basic-1_0.html#Scopes)_
 
-Le protocole OpenID Connect défini un certain nombre de [scopes standards](https://openid.net/specs/openid-connect-basic-1_0.html#Scopes) qu'il est possible d'étendre avec des *scopes* spécifiques supplémentaires en fonction du besoin de l'*identity provider*.
+Le protocole OpenID Connect défini un certain nombre de [scopes standards](https://openid.net/specs/openid-connect-basic-1_0.html#Scopes) qu'il est possible d'étendre avec des _scopes_ spécifiques supplémentaires en fonction du besoin de l'_identity provider_.
 
-*En bref :* Les scopes permettent de définir l'ensemble des informations à disposition du Fournisseur de Services pour une cinématique. 
+_En bref :_ Les scopes permettent de définir l'ensemble des informations à disposition du Fournisseur de Services pour une cinématique.
 
-### Qu'est ce qu'un claim dans OpenID Connect ? 
+### Qu'est ce qu'un claim dans OpenID Connect ?
 
-Dans OpenId Connect, un claim est une information relative à l'utilisateur ou à la phase l'authentification. Ces informations peuvent être disponibles soit dans l'ID Token, soit dans la réponse du UserInfo. Les claims retournés dans ces jetons dépendent des scopes associés à l'*access token*. 
+Dans OpenId Connect, un claim est une information relative à l'utilisateur ou à la phase l'authentification. Ces informations peuvent être disponibles soit dans l'ID Token, soit dans la réponse du UserInfo. Les claims retournés dans ces jetons dépendent des scopes associés à l'_access token_.
 
 Le protocole OpenId Connect defini un certain nombre de [claims standards](https://openid.net/specs/openid-connect-core-1_0.html#Claims).
 
-*En Bref :* Les claims sont les informations sur l'utilisateur ou la phase d'authentification disponible dans l'ID Token ou dans la réponse de UserInfo. 
+_En Bref :_ Les claims sont les informations sur l'utilisateur ou la phase d'authentification disponible dans l'ID Token ou dans la réponse de UserInfo.
 
 La liste des données renvoyées par les Fournisseurs d'Identité est disponible [ici](./donnees_fournies.md)
 
 ### Les données sur l'authentification
 
-Les claims relatifs à l'authentification disponibles par ProConnect sont des claims standards et sont disponibles uniquement dans l'ID Token. Ces claims sont les suivants : 
+Les claims relatifs à l'authentification disponibles par ProConnect sont des claims standards et sont disponibles uniquement dans l'ID Token. Ces claims sont les suivants :
 
 - amr
 - acr
@@ -37,21 +36,31 @@ Les claims relatifs à l'authentification disponibles par ProConnect sont des cl
 
 ### Correspondance entre scope et claims sur ProConnect
 
-Le tableau suivant décrit la liste des *claims* accessible en fonction des *scopes* associés à l'access token. 
+Le tableau suivant décrit la liste des _claims_ accessible en fonction des _scopes_ associés à l'access token.
 Tous les Fournisseurs de Service intégrés depuis août 2024 ont accès par défaut à tous les scopes suivants:
 
-| Scope       | Claims   |
-| --- | --- |
-| openid | sub |
-| given_name | given_name|
-| usual_name| usual_name |
-| email | email |
-| uid | uid|
-| siret | siret |
-| idp_id | idp_id|
+| Scope      | Claims     |
+| ---------- | ---------- |
+| openid     | sub        |
+| given_name | given_name |
+| usual_name | usual_name |
+| email      | email      |
+| uid        | uid        |
+| siret      | siret      |
+| idp_id     | idp_id     |
+
+#### Le scope "phone"
 
 Le claim "phone_number" existe également pour le scope phone.
 
-| Scope       | Claims   |
-| --- | --- |
+| Scope | Claims       |
+| ----- | ------------ |
 | phone | phone_number |
+
+#### Le scope "custom"
+
+| Scope  | Claims |
+| ------ | ------ |
+| custom | custom |
+
+Les Fournisseurs de Service qui le souhaitent peuvent appeler le scope optionnel "custom". Pour plus d'informations, lire l'[article dédié](custom-scope.md).


### PR DESCRIPTION
Nous venons de livrer [la feature de récupération des identités custom](https://trello.com/c/78YIhyQK/13-ajouter-un-scope-custom). Voici la doc qui explique cette mécanique.