### PR TITLE
Update custom-scope.md , fields are in camelCase

### DIFF
--- a/doc_fs/custom-scope.md
+++ b/doc_fs/custom-scope.md
@@ -29,8 +29,8 @@ Par exemple:
 {
   "sub": "sub-idp",
   ...,
-  "structure_travail": "59194",
-  "site_travail": "DRHAUTS-DE-FRANCE/PFPPLATEFORMESERVICESADISTANCE(HDF0262005733)"
+  "structureTravail": "59194",
+  "siteTravail": "DRHAUTS-DE-FRANCE/PFPPLATEFORMESERVICESADISTANCE(HDF0262005733)"
 }
 ```
 
@@ -41,8 +41,8 @@ Dans ce cas, ProConnect placera ces valeurs dans l'objet `custom`:
   "sub": "7396c91e-b9f2-4f9d-8547-5e9b3332725b",
   ...
   "custom": {
-    "structure_travail": "59194",
-    "site_travail": "DRHAUTS-DE-FRANCE/PFPPLATEFORMESERVICESADISTANCE(HDF0262005733)"
+    "structureTravail": "59194",
+    "siteTravail": "DRHAUTS-DE-FRANCE/PFPPLATEFORMESERVICESADISTANCE(HDF0262005733)"
   }
 }
 


### PR DESCRIPTION
This documentation does not reflect what actually is provided by the service.  `structureTravail` and `siteTravail` are provided in camel case. 

This fixes the docs