### PR TITLE
Fix dead links in doc_fs documentation

### DIFF
--- a/doc_fs/README.md
+++ b/doc_fs/README.md
@@ -14,8 +14,8 @@ Cette documentation est à destination des Fournisseurs de Services souhaitant i
 
 - [ ] Je me familiarise avec le flux OIDC - authorization code flow : voir [concepts de base](resources/flux_oidc.md). NB: si vous êtes Fournisseur de Service, ProConnect est votre _provider_ et vous êtes _client_.
 - [ ] Je souhaite lancer les développements en test : je renseigne [le formulaire dédié](https://www.demarches-simplifiees.fr/commencer/demande-creation-fs-fca). L'équipe me fournit alors mon `client_id` et mon `client_secret`, à l'adresse e-mail associée à la demande Démarches Simplifiées. Si vous êtes identifié via FranceConnect, il s'agit alors probablement de votre adresse e-mail personnelle.
-- [ ] J’ai implémenté la cinématique OIDC (Authorization Code Flow): voir l'[implémentation technique](doc_fs/implementation_technique.md)
-- [ ] Je contractualise officiellement ma collaboration avec la DINUM en remplissant le [DataPass dédié](./doc_fs/datapass-fs.md)
+- [ ] J’ai implémenté la cinématique OIDC (Authorization Code Flow): voir l'[implémentation technique](/doc_fs/implementation_technique.md)
+- [ ] Je contractualise officiellement ma collaboration avec la DINUM en remplissant le [DataPass dédié](/doc_fs/datapass-fs.md)
 - [ ] Le DataPass étant validé, j’ai récupéré mon `client_id` et mon `client_secret` de production en remplissant [le formulaire dédié](https://www.demarches-simplifiees.fr/commencer/demande-creation-fs-fca) avec les informations de production
 - [ ] Ouverture du service en production 🚀
 


### PR DESCRIPTION
Des liens morts existent dans la documentation.

Le fix consiste à faire des liens des chemins absolus, ce qui corrige le souci