### PR TITLE
🐛 Fix error on links in idp Readme

### DIFF
--- a/doc_fi/README.md
+++ b/doc_fi/README.md
@@ -1,7 +1,6 @@
 [Accueil](README.md) > ProConnect - Fournisseur d'identité
 
-___
-
+---
 
 # Documentation Fournisseur d'Identité
 
@@ -12,21 +11,19 @@ Vous souhaitez rejoindre la fédération d'identité et être Fournisseur d'Iden
 Voici un résumé des étapes pour être Fournisseur d'Identité ProConnect :
 
 - [ ] Je vérifie que je respecte bien les [pré-requis pour devenir FI pour ProConnect](./doc_fi/prerequis-fi.md)
-- [ ] Je me familiarise avec le flux OIDC - authorization code flow : voir [concepts de base](resources/flux_oidc.md). NB: si vous êtes Fournisseur d'Identité, vous êtes *provider* et ProConnect est *client*.
+- [ ] Je me familiarise avec le flux OIDC - authorization code flow : voir [concepts de base](resources/flux_oidc.md). NB: si vous êtes Fournisseur d'Identité, vous êtes _provider_ et ProConnect est _client_.
 - [ ] Je configure mon Fournisseur d'Identité pour qu'il puisse s'intégrer à la fédération ProConnect avec le [mode d'emploi technique](doc_fi/configuration.md)
 - [ ] Je renseigne à l'équipe ProConnect les informations nécessaires pour que ProConnect créé la configuration de mon FI en remplissant [le formulaire dédié](https://www.demarches-simplifiees.fr/commencer/demande-creation-fi-fca)
 - [ ] [_Optionnel_] Je contacte l'équipe ProConnect pour qu'elle puisse répondre à mes questions si j'en ai : support+partenaire@agentconnect-ntitfa.on.crisp.email ou [sur notre chaîne Tchap](https://www.tchap.gouv.fr/#/room/!kBghcRpyMNThkFQjdW:agent.dinum.tchap.gouv.fr)
-- [ ]  Je contractualise officiellement ma collaboration avec la Dinum en remplissant le [DataPass dédié](https://datapass.api.gouv.fr/agent-connect-fi).
+- [ ] Je contractualise officiellement ma collaboration avec la Dinum en remplissant le [DataPass dédié](https://datapass.api.gouv.fr/agent-connect-fi).
 - [ ] Je remplis [le formulaire](https://www.demarches-simplifiees.fr/commencer/demande-creation-fi-fca) pour que ProConnect créé la configuration pour mon FI en production
-- [ ]  Mise en production 🚀
+- [ ] Mise en production 🚀
 
-___
-
+---
 
 ## 2. 📚 Ressources supplémentaires
 
-- [Quels changements dois-je effectuer pour passer d'AgentConnect à ProConnect ?](./doc_fi/changement-agentconnect-proconnect-fi.md)
-- [Qu'est-ce que la plateforme "Internet", la plateforme "RIE" et l'"Hybridge" ?](doc_fi/plateformes_fi.md)
-- [Quels sont les certificats d'authentification ?](./doc_fi/certificats_fi.md)
-- [Glossaire](resources/glossaire.md)
-
+- [Quels changements dois-je effectuer pour passer d'AgentConnect à ProConnect ?](./changement-agentconnect-proconnect-fi.md)
+- [Qu'est-ce que la plateforme "Internet", la plateforme "RIE" et l'"Hybridge" ?](./plateformes_fi.md)
+- [Quels sont les certificats d'authentification ?](./certificats_fi.md)
+- [Glossaire](../resources/glossaire.md)


### PR DESCRIPTION
When we use the "Ressources supplémentaires" links, there was an error. This MR redirect to the correct links.
Some minor corrections thanks to linter.