### PR TITLE
fix wrong link to FI pre-requisites documentation

### DIFF
--- a/doc_fi/README.md
+++ b/doc_fi/README.md
@@ -10,7 +10,7 @@ Vous souhaitez rejoindre la fédération d'identité et être Fournisseur d'Iden
 
 Voici un résumé des étapes pour être Fournisseur d'Identité ProConnect :
 
-- [ ] Je vérifie que je respecte bien les [pré-requis pour devenir FI pour ProConnect](./doc_fi/prerequis-fi.md)
+- [ ] Je vérifie que je respecte bien les [pré-requis pour devenir FI pour ProConnect](./prerequis-fi.md)
 - [ ] Je me familiarise avec le flux OIDC - authorization code flow : voir [concepts de base](resources/flux_oidc.md). NB: si vous êtes Fournisseur d'Identité, vous êtes _provider_ et ProConnect est _client_.
 - [ ] Je configure mon Fournisseur d'Identité pour qu'il puisse s'intégrer à la fédération ProConnect avec le [mode d'emploi technique](doc_fi/configuration.md)
 - [ ] Je renseigne à l'équipe ProConnect les informations nécessaires pour que ProConnect créé la configuration de mon FI en remplissant [le formulaire dédié](https://www.demarches-simplifiees.fr/commencer/demande-creation-fi-fca)


### PR DESCRIPTION
Absolute path was used as relative