### PR TITLE
Fix amr claim name for authorization request

### DIFF
--- a/resources/claim_amr.md
+++ b/resources/claim_amr.md
@@ -6,7 +6,7 @@ Par défaut ce claim `amr` n'est pas retourné dans l'idToken, il doit être dem
 
 | clé          | valeur  |
 |--------------|---------|
-| `id_token`   | `{"id_token":{"auth_time":{"essential":true}}}` |
+| `id_token`   | `{"id_token":{"amr":{"essential":true}}}` |
 
 Les valeurs possibles pour `amr` sont les suivantes :
 


### PR DESCRIPTION
Hello,

current documentation on AMR seems wrong, the claim name should be `amr` and not `auth_time`